### PR TITLE
Use cargo-team maintained home crate instead of dirs-next

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ version = "0.4.0"
 
 [dependencies]
 cfg-if = "1.0.0"
-dirs-next = "2.0.0"
+home = "0.5.4"
 thiserror = "1.0.22"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,9 +83,9 @@
 pub mod app_strategy;
 pub mod base_strategy;
 
-/// A convenience function that wraps the [`home_dir`](https://docs.rs/dirs-next/1/dirs_next/fn.home_dir.html) function from the [dirs-next](https://docs.rs/dirs-next) crate.
+/// A convenience function that wraps the [`home_dir`](https://docs.rs/home/0.5.4/home/fn.home_dir.html) function from the [home](https://docs.rs/home) crate.
 pub fn home_dir() -> Result<std::path::PathBuf, HomeDirError> {
-    dirs_next::home_dir().ok_or(HomeDirError)
+    home::home_dir().ok_or(HomeDirError)
 }
 
 /// This error occurs when the home directory cannot be located.


### PR DESCRIPTION
The cargo team maintains the [`home`](https://github.com/rust-lang/cargo/tree/master/crates/home) crate for use in cargo & rustup. `dirs-next` is a much larger dependency & we only need a single function. It is also no longer maintained.