### PR TITLE
Conditionally compile Apple/Windows

### DIFF
--- a/src/app_strategy.rs
+++ b/src/app_strategy.rs
@@ -113,18 +113,24 @@ macro_rules! create_choose_app_strategy {
 
 cfg_if::cfg_if! {
     if #[cfg(target_os = "windows")] {
+        mod windows;
+
+        pub use windows::Windows;
+
         create_choose_app_strategy!(choose_app_strategy, Windows);
+    } else if #[cfg(any(target_os = "macos", target_os = "ios"))] {
+        mod apple;
+
+        pub use apple::Apple;
+
+        create_choose_app_strategy!(choose_app_strategy, Xdg);
     } else {
         create_choose_app_strategy!(choose_app_strategy, Xdg);
     }
 }
 
-mod apple;
 mod unix;
-mod windows;
 mod xdg;
 
-pub use apple::Apple;
 pub use unix::Unix;
-pub use windows::Windows;
 pub use xdg::Xdg;

--- a/src/base_strategy.rs
+++ b/src/base_strategy.rs
@@ -35,16 +35,22 @@ macro_rules! create_choose_base_strategy {
 
 cfg_if::cfg_if! {
     if #[cfg(target_os = "windows")] {
+        mod windows;
+
+        pub use windows::Windows;
+
         create_choose_base_strategy!(choose_base_strategy, Windows);
+    } else if #[cfg(any(target_os = "macos", target_os = "ios"))] {
+        mod apple;
+
+        pub use apple::Apple;
+
+        create_choose_base_strategy!(choose_base_strategy, Xdg);
     } else {
         create_choose_base_strategy!(choose_base_strategy, Xdg);
     }
 }
 
-mod apple;
-mod windows;
 mod xdg;
 
-pub use apple::Apple;
-pub use windows::Windows;
 pub use xdg::Xdg;


### PR DESCRIPTION
Apple/Windows conventions should never be used on another OS. Conditionally compiling it makes it impossible to use it incorrectly & also reduces compilation size/time.