### PR TITLE
Support runtime directory

### DIFF
--- a/src/app_strategy.rs
+++ b/src/app_strategy.rs
@@ -86,6 +86,10 @@ pub trait AppStrategy: Sized {
     /// State directory may not to exist for all platforms.
     fn state_dir(&self) -> Option<PathBuf>;
 
+    /// Gets the runtime directory for your application.
+    /// Runtime directory may not to exist for all platforms.
+    fn runtime_dir(&self) -> Option<PathBuf>;
+
     /// Constructs a path inside your application’s configuration directory to which a path of your choice has been appended.
     fn in_config_dir<P: AsRef<OsStr>>(&self, path: P) -> PathBuf {
         in_dir_method!(self, path, config_dir)

--- a/src/app_strategy/apple.rs
+++ b/src/app_strategy/apple.rs
@@ -34,6 +34,10 @@ use std::path::PathBuf;
 ///     app_strategy.state_dir(),
 ///     None
 /// );
+/// assert_eq!(
+///     app_strategy.runtime_dir(),
+///     None
+/// );
 /// ```
 #[derive(Debug)]
 pub struct Apple {
@@ -64,6 +68,10 @@ impl super::AppStrategy for Apple {
     }
 
     fn state_dir(&self) -> Option<PathBuf> {
+        None
+    }
+
+    fn runtime_dir(&self) -> Option<PathBuf> {
         None
     }
 }

--- a/src/app_strategy/unix.rs
+++ b/src/app_strategy/unix.rs
@@ -32,6 +32,10 @@ use std::path::PathBuf;
 ///     app_strategy.state_dir().unwrap().strip_prefix(&home_dir),
 ///     Ok(Path::new(".vim/state/")
 /// ));
+/// assert_eq!(
+///     app_strategy.runtime_dir().unwrap().strip_prefix(&home_dir),
+///     Ok(Path::new(".vim/runtime/")
+/// ));
 /// ```
 #[derive(Debug)]
 pub struct Unix {
@@ -63,5 +67,9 @@ impl super::AppStrategy for Unix {
 
     fn state_dir(&self) -> Option<PathBuf> {
         Some(self.root_dir.join("state/"))
+    }
+
+    fn runtime_dir(&self) -> Option<PathBuf> {
+        Some(self.root_dir.join("runtime/"))
     }
 }

--- a/src/app_strategy/windows.rs
+++ b/src/app_strategy/windows.rs
@@ -34,6 +34,10 @@ use std::path::PathBuf;
 ///     app_strategy.state_dir(),
 ///     None
 /// );
+/// assert_eq!(
+///     app_strategy.runtime_dir(),
+///     None
+/// );
 /// ```
 #[derive(Debug)]
 pub struct Windows {
@@ -74,6 +78,10 @@ impl super::AppStrategy for Windows {
     }
 
     fn state_dir(&self) -> Option<PathBuf> {
+        None
+    }
+
+    fn runtime_dir(&self) -> Option<PathBuf> {
         None
     }
 }

--- a/src/app_strategy/xdg.rs
+++ b/src/app_strategy/xdg.rs
@@ -17,6 +17,7 @@ use std::path::PathBuf;
 /// std::env::remove_var("XDG_DATA_HOME");
 /// std::env::remove_var("XDG_CACHE_HOME");
 /// std::env::remove_var("XDG_STATE_HOME");
+/// std::env::remove_var("XDG_RUNTIME_DIR");
 ///
 /// let app_strategy = Xdg::new(AppStrategyArgs {
 ///     top_level_domain: "hm".to_string(),
@@ -42,6 +43,10 @@ use std::path::PathBuf;
 ///     app_strategy.state_dir().unwrap().strip_prefix(&home_dir),
 ///     Ok(Path::new(".local/state/htop/")
 /// ));
+/// assert_eq!(
+///     app_strategy.runtime_dir(),
+///     None
+/// );
 /// ```
 ///
 /// This next example gives the environment variables values:
@@ -73,11 +78,17 @@ use std::path::PathBuf;
 /// } else {
 ///     "/my_state_location/"
 /// };
+/// let runtime_path = if cfg!(windows) {
+///     "C:\\my_runtime_location\\"
+/// } else {
+///     "/my_runtime_location/"
+/// };
 ///
 /// std::env::set_var("XDG_CONFIG_HOME", config_path);
 /// std::env::set_var("XDG_DATA_HOME", data_path);
 /// std::env::set_var("XDG_CACHE_HOME", cache_path);
 /// std::env::set_var("XDG_STATE_HOME", state_path);
+/// std::env::set_var("XDG_RUNTIME_DIR", runtime_path);
 ///
 /// let app_strategy = Xdg::new(AppStrategyArgs {
 ///     top_level_domain: "hm".to_string(),
@@ -89,6 +100,7 @@ use std::path::PathBuf;
 /// assert_eq!(app_strategy.data_dir(), Path::new(&format!("{}/htop/", data_path)));
 /// assert_eq!(app_strategy.cache_dir(), Path::new(&format!("{}/htop/", cache_path)));
 /// assert_eq!(app_strategy.state_dir().unwrap(), Path::new(&format!("{}/htop/", state_path)));
+/// assert_eq!(app_strategy.runtime_dir().unwrap(), Path::new(&format!("{}/htop/", runtime_path)));
 /// ```
 ///
 /// The XDG spec requires that when the environment variables’ values are not absolute paths, their values should be ignored. This example exemplifies this behaviour:
@@ -104,6 +116,7 @@ use std::path::PathBuf;
 /// std::env::set_var("XDG_DATA_HOME", "./another_one/");
 /// std::env::set_var("XDG_CACHE_HOME", "yet_another/");
 /// std::env::set_var("XDG_STATE_HOME", "./and_another");
+/// std::env::set_var("XDG_RUNTIME_DIR", "relative_path/");
 ///
 /// let app_strategy = Xdg::new(AppStrategyArgs {
 ///     top_level_domain: "hm".to_string(),
@@ -130,6 +143,10 @@ use std::path::PathBuf;
 ///     app_strategy.state_dir().unwrap().strip_prefix(&home_dir),
 ///     Ok(Path::new(".local/state/htop/")
 /// ));
+/// assert_eq!(
+///     app_strategy.runtime_dir(),
+///     None
+/// );
 /// ```
 #[derive(Debug)]
 pub struct Xdg {
@@ -166,5 +183,11 @@ impl super::AppStrategy for Xdg {
                 .unwrap()
                 .join(&self.unixy_name),
         )
+    }
+
+    fn runtime_dir(&self) -> Option<PathBuf> {
+        self.base_strategy
+            .runtime_dir()
+            .map(|runtime_dir| runtime_dir.join(&self.unixy_name))
     }
 }

--- a/src/base_strategy.rs
+++ b/src/base_strategy.rs
@@ -22,6 +22,10 @@ pub trait BaseStrategy: Sized {
     /// Gets the user’s state directory.
     /// State directory may not exist for all platforms.
     fn state_dir(&self) -> Option<PathBuf>;
+
+    /// Gets the user’s runtime directory.
+    /// Runtime directory may not exist for all platforms.
+    fn runtime_dir(&self) -> Option<PathBuf>;
 }
 
 macro_rules! create_choose_base_strategy {

--- a/src/base_strategy/apple.rs
+++ b/src/base_strategy/apple.rs
@@ -27,6 +27,10 @@ use std::path::PathBuf;
 ///     base_strategy.state_dir(),
 ///     None
 /// );
+/// assert_eq!(
+///     base_strategy.runtime_dir(),
+///     None
+/// );
 /// ```
 #[derive(Debug)]
 pub struct Apple {
@@ -56,6 +60,10 @@ impl super::BaseStrategy for Apple {
     }
 
     fn state_dir(&self) -> Option<PathBuf> {
+        None
+    }
+
+    fn runtime_dir(&self) -> Option<PathBuf> {
         None
     }
 }

--- a/src/base_strategy/windows.rs
+++ b/src/base_strategy/windows.rs
@@ -27,6 +27,10 @@ use std::path::PathBuf;
 ///     base_strategy.state_dir(),
 ///     None
 /// );
+/// assert_eq!(
+///     base_strategy.runtime_dir(),
+///     None
+/// );
 /// ```
 #[derive(Debug)]
 pub struct Windows {
@@ -55,6 +59,10 @@ impl super::BaseStrategy for Windows {
     }
 
     fn state_dir(&self) -> Option<PathBuf> {
+        None
+    }
+
+    fn runtime_dir(&self) -> Option<PathBuf> {
         None
     }
 }


### PR DESCRIPTION
XDG_RUNTIME_DIR is a part of the [`XDG Base Directory Specification`](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
I want to incorporate this crate in a couple of tools which require runtime_dir.