### PR TITLE
Make macOS bundle ID match the `directories` crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Etcetera has 2 modes of operation: `BaseStrategy` & `AppStrategy`:
   For eg. if you provide the following details: `{ top_level_domain: "org", author: "Acme Corp", app_name: "Frobnicator Plus" }`, you'll get:
   - XDG: `~/.config/frobnicator-plus`
   - Unix: `~/.frobnicator-plus`
-  - Apple: `~/Library/Preferences/org.acmecorp.FrobnicatorPlus`
+  - Apple: `~/Library/Preferences/org.acme-corp.Frobnicator-Plus`
   - Windows: `~\AppData\Roaming\Acme Corp\Frobnicator Plus`
 
 Note: the location of the home (~) is determined by the [`home`](https://docs.rs/home/0.5.4/home/fn.home_dir.html) crate.

--- a/src/app_strategy.rs
+++ b/src/app_strategy.rs
@@ -27,15 +27,18 @@ impl AppStrategyArgs {
     ///     app_name: "Frobnicator Plus".to_string(),
     /// };
     ///
-    /// assert_eq!(strategy_args.bundle_id().replace(' ', ""), "org.acmecorp.FrobnicatorPlus".to_string());
+    /// assert_eq!(strategy_args.bundle_id(), "org.acme-corp.Frobnicator-Plus".to_string());
     /// ```
     pub fn bundle_id(&self) -> String {
-        format!(
-            "{}.{}.{}",
-            self.top_level_domain,
-            self.author.to_lowercase(),
-            self.app_name
-        )
+        let author = self.author.to_lowercase().replace(' ', "-");
+        let app_name = self.app_name.replace(' ', "-");
+        let mut parts = vec![
+            self.top_level_domain.as_str(),
+            author.as_str(),
+            app_name.as_str(),
+        ];
+        parts.retain(|part| !part.is_empty());
+        parts.join(".")
     }
 
     /// Returns a ‘unixy’ version of the application’s name, akin to what would usually be used as a binary name.

--- a/src/app_strategy/apple.rs
+++ b/src/app_strategy/apple.rs
@@ -24,15 +24,15 @@ use std::path::{Path, PathBuf};
 /// );
 /// assert_eq!(
 ///     app_strategy.config_dir().strip_prefix(&home_dir),
-///     Ok(Path::new("Library/Preferences/org.acmecorp.FrobnicatorPlus/"))
+///     Ok(Path::new("Library/Preferences/org.acme-corp.Frobnicator-Plus/"))
 /// );
 /// assert_eq!(
 ///     app_strategy.data_dir().strip_prefix(&home_dir),
-///     Ok(Path::new("Library/Application Support/org.acmecorp.FrobnicatorPlus/"))
+///     Ok(Path::new("Library/Application Support/org.acme-corp.Frobnicator-Plus/"))
 /// );
 /// assert_eq!(
 ///     app_strategy.cache_dir().strip_prefix(&home_dir),
-///     Ok(Path::new("Library/Caches/org.acmecorp.FrobnicatorPlus/"))
+///     Ok(Path::new("Library/Caches/org.acme-corp.Frobnicator-Plus/"))
 /// );
 /// assert_eq!(
 ///     app_strategy.state_dir(),
@@ -55,7 +55,7 @@ impl super::AppStrategy for Apple {
     fn new(args: super::AppStrategyArgs) -> Result<Self, Self::CreationError> {
         Ok(Self {
             base_strategy: base_strategy::Apple::new()?,
-            bundle_id: args.bundle_id().replace(' ', ""),
+            bundle_id: args.bundle_id(),
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //! Let’s take an application created by `Acme Corp` with the name `Frobnicator Plus` and the top-level domain of `jrg` as an example.
 //! - XDG strategy would place these in `~/.config/frobnicator-plus`.
 //! - Unix strategy would place these in `~/.frobnicator-plus`.
-//! - Apple strategy would place these in `~/Library/Preferences/org.acmecorp.FrobnicatorPlus`.
+//! - Apple strategy would place these in `~/Library/Preferences/org.acme-corp.Frobnicator-Plus`.
 //! - Windows strategy would place these in `~\AppData\Roaming\Acme Corp\Frobnicator Plus`.
 //!
 //! ```


### PR DESCRIPTION
This is a breaking change for anybody already using the crate, but necessary for people to switch over from the `directories` crate.

Instead of stripping spaces from the organization and application names, we now replace them with hyphens as `directories` does. In addition, if part of the bundle ID is not specified (e.g. the user only provides an application name), we don't want to output extra dots in between it and the missing parts.