### PR TITLE
Widen windows-sys bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ home = "0.5"
 
 # We should keep this in sync with the `home` crate.
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.48", features = ["Win32_Foundation", "Win32_UI_Shell"] }
+windows-sys = { version = ">=0.48, <=0.59", features = ["Win32_Foundation", "Win32_UI_Shell"] }


### PR DESCRIPTION
The recent changes in windows-sys (https://github.com/microsoft/windows-rs/releases/tag/0.59.0) do not break etcetera (`cargo test` passes on both versions), but the strict bounds prevent downstream crates from upgrading, or as in our case, we get duplicate versions of windows-sys. Instead, we widen the bound to support both the old and the new version.