### PR TITLE
Allow compatibility with recent versions of `home`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ description = "An unopinionated library for obtaining configuration, data, cache
 
 [dependencies]
 cfg-if = "1"
-home = ">=0.5,<0.5.11"
+home = "0.5"
 
 # We should keep this in sync with the `home` crate.
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
According to https://github.com/lunacookies/etcetera/issues/28, the reason for using `home = ">=0.5, <0.5.11"` is to make `etcetera` compatible with a larger range of compiler versions. However, that is not what that accomplishes. It does not increase the range of compiler versions that `etcetera` is compatible with. The only thing it accomplishes is making `etcetera` compatible with a narrower range of `home` versions. If some crate with a higher MSRV than `etcetera` wants to use a higher version of `home`, you have made it impossible for them to do so.

The correct way for applications (binaries) to support installation using an older version of Rust is to use a lockfile (Cargo.lock). It is misguided for libraries to try to provide that effect using `<` constraints in a Cargo.toml.