### PR TITLE
Support non-UTF8 dirs

### DIFF
--- a/src/base_strategy/xdg.rs
+++ b/src/base_strategy/xdg.rs
@@ -167,7 +167,7 @@ impl Xdg {
     }
 
     fn env_var_or_none(env_var: &str) -> Option<PathBuf> {
-        std::env::var(env_var).ok().and_then(|path| {
+        std::env::var_os(env_var).and_then(|path| {
             let path = PathBuf::from(path);
 
             // Return None if the path obtained from the environment variable isn’t absolute.


### PR DESCRIPTION
This code doesn't need the UTF8 checking performed by `env::var`. It just needs an OS string that can be treated as a path.