### PR TITLE
chore(README): fix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ Etcetera also provides convenience functions for selecting the appropriate strat
 
 ## 
 
-See the ![documentation](https://docs.rs/etcetera) for examples.
+See the [documentation](https://docs.rs/etcetera) for examples.


### PR DESCRIPTION
Otherwise with the `!` github thinks its a image and tried to link to:
```txt
https://camo.githubusercontent.com/afb551659088ed6e5c36e64148ed050aeb6f323b37184d91f9b39bd4d4147da5/68747470733a2f2f646f63732e72732f6574636574657261
```

Which gives error:
```txt
Non-Image content-type returned
```