### PR TITLE
chore: Use std::env::home_dir

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        toolchain: [beta, stable, 1.81.0]
+        toolchain: [beta, stable, 1.85.0]
 
     name: Test on ${{ matrix.os }} with Rust ${{ matrix.toolchain }}
     runs-on: ${{ matrix.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,11 @@ keywords = ["xdg", "dirs", "directories", "basedir", "path"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/lunacookies/etcetera"
-rust-version = "1.70.0"
+rust-version = "1.85.0"
 description = "An unopinionated library for obtaining configuration, data, cache, & other directories"
 
 [dependencies]
 cfg-if = "1"
-home = "0.5"
 
 # We should keep this in sync with the `home` crate.
 [target.'cfg(windows)'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,9 +108,10 @@ pub mod base_strategy;
 pub use app_strategy::{choose_app_strategy, AppStrategy, AppStrategyArgs};
 pub use base_strategy::{choose_base_strategy, BaseStrategy};
 
-/// A convenience function that wraps the [`home_dir`](https://docs.rs/home/0.5.4/home/fn.home_dir.html) function from the [home](https://docs.rs/home) crate.
+/// A convenience function that wraps the [`home_dir`](https://doc.rust-lang.org/stable/std/env/fn.home_dir.html) function from the standard library.
 pub fn home_dir() -> Result<std::path::PathBuf, HomeDirError> {
-    home::home_dir().ok_or(HomeDirError)
+    #[allow(deprecated)]
+    std::env::home_dir().ok_or(HomeDirError)
 }
 
 /// This error occurs when the home directory cannot be located.


### PR DESCRIPTION
The version of home_dir in the standard library was fixed in rust 1.85, and the home crate now recommends using that instead of depending on that crate. See https://github.com/rust-lang/cargo/blob/master/crates/home/README.md

This does bump up the MSRV