### PR TITLE
Fix URL for XDG Base Directories specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you want, you can use v0.9 with an MSRV of 1.70.0 or v0.10 with an MSRV of 1.
 
 Etcetera supports the following conventions:
 
-- the [XDG base directory](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+- the [XDG base directory](https://standards.freedesktop.org/basedir/latest/)
 - Apple's [Standard Directories](https://developer.apple.com/library/content/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html)
 - Window's [Known Folder Locations](https://docs.microsoft.com/en-us/windows/win32/shell/knownfolderid)
 - the "Unix Single-folder Convention" i.e. everything in `~/.myapp`

--- a/src/app_strategy.rs
+++ b/src/app_strategy.rs
@@ -101,7 +101,7 @@ pub trait AppStrategy {
     /// directory related to ownership, permissions, and persistence. This library does not check
     /// these requirements.
     ///
-    /// [spec]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+    /// [spec]: https://specifications.freedesktop.org/basedir/latest/
     fn runtime_dir(&self) -> Option<PathBuf>;
 
     /// Constructs a path inside your application’s configuration directory to which a path of your choice has been appended.

--- a/src/app_strategy/xdg.rs
+++ b/src/app_strategy/xdg.rs
@@ -2,7 +2,7 @@ use crate::base_strategy::BaseStrategy;
 use crate::{HomeDirError, base_strategy};
 use std::path::{Path, PathBuf};
 
-/// This strategy implements the [XDG Base Directories Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html). It is the most common on Linux, but is increasingly being adopted elsewhere.
+/// This strategy implements the [XDG Base Directories Specification](https://specifications.freedesktop.org/basedir/latest/). It is the most common on Linux, but is increasingly being adopted elsewhere.
 ///
 /// This initial example removes all the XDG environment variables to show the strategy’s use of the XDG default directories.
 ///

--- a/src/base_strategy.rs
+++ b/src/base_strategy.rs
@@ -28,7 +28,7 @@ pub trait BaseStrategy {
     /// directory related to ownership, permissions, and persistence. This library does not check
     /// these requirements.
     ///
-    /// [spec]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+    /// [spec]: https://specifications.freedesktop.org/basedir/latest/
     fn runtime_dir(&self) -> Option<PathBuf>;
 }
 

--- a/src/base_strategy/xdg.rs
+++ b/src/base_strategy/xdg.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use crate::HomeDirError;
 
-/// This strategy implements the [XDG Base Directories Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html). It is the most common on Linux, but is increasingly being adopted elsewhere.
+/// This strategy implements the [XDG Base Directories Specification](https://specifications.freedesktop.org/basedir/latest/). It is the most common on Linux, but is increasingly being adopted elsewhere.
 ///
 /// This initial example removes all the XDG environment variables to show the strategy’s use of the XDG default directories.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! # Conventions
 //! Etcetera supports the following conventions:
-//! - the [XDG base directory](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+//! - the [XDG base directory](https://standards.freedesktop.org/basedir/latest/)
 //! - Apple's [Standard Directories](https://developer.apple.com/library/content/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html)
 //! - Window's [Known Folder Locations](https://docs.microsoft.com/en-us/windows/win32/shell/knownfolderid)
 //! - the "Unix Single-folder Convention" i.e. everything in `~/.myapp`


### PR DESCRIPTION
Apparently the URL for the latest version of the XDG Base Directories specification has changed. 
This PR changes it to what I think is the correct URL.