### PR TITLE
Drop cfg-if dependency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        toolchain: [beta, stable, 1.87.0]
+        toolchain: [beta, stable, 1.95.0]
 
     name: Test on ${{ matrix.os }} with Rust ${{ matrix.toolchain }}
     runs-on: ${{ matrix.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcetera"
-version = "0.11.0"
+version = "0.12.0"
 categories = ["config"]
 documentation = "https://docs.rs/etcetera"
 edition = "2024"
@@ -9,11 +9,8 @@ keywords = ["xdg", "dirs", "directories", "basedir", "path"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/lunacookies/etcetera"
-rust-version = "1.87.0"
+rust-version = "1.95.0"
 description = "An unopinionated library for obtaining configuration, data, cache, & other directories"
-
-[dependencies]
-cfg-if = "1"
 
 # We should keep this in sync with the `home` crate.
 [target.'cfg(windows)'.dependencies]

--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@ This is a Rust library that allows you to determine the locations of configurati
 Existing Rust libraries generally do not give you a choice in terms of which standards/conventions they follow.
 Etcetera, on the other hand, gives you the choice.
 
-MSRV: 1.87.0
+MSRV: 1.95.0
 
-Note: The MSRV was raised to 1.87.0 in v0.11 to remove the dependency on the `home` crate & instead use the undeprecated `std::env::home_dir`.
-If you want, you can use v0.9 with an MSRV of 1.70.0 or v0.10 with an MSRV of 1.81.0 instead.
+Note: The MSRV was raised to 1.95.0 in v0.12 to remove the dependency on the `cfg-if` crate & instead use the `cfg_select!` macro introduced in that version.
+If you want, you can use one of the following releases with a lower MSRV:
+- v0.9 with an MSRV of 1.70.0
+- v0.10 with an MSRV of 1.81.0
+- v0.11 with an MSRC of 1.87.0
 
 ## Conventions
 

--- a/src/app_strategy.rs
+++ b/src/app_strategy.rs
@@ -154,12 +154,14 @@ macro_rules! create_strategies {
     };
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(target_os = "windows")] {
+cfg_select! {
+    target_os = "windows" => {
         create_strategies!(Windows, Windows);
-    } else if #[cfg(any(target_os = "macos", target_os = "ios"))] {
+    },
+    any(target_os = "macos", target_os = "ios") => {
         create_strategies!(Apple, Xdg);
-    } else {
+    },
+    _ => {
         create_strategies!(Xdg, Xdg);
     }
 }

--- a/src/app_strategy.rs
+++ b/src/app_strategy.rs
@@ -157,10 +157,10 @@ macro_rules! create_strategies {
 cfg_select! {
     target_os = "windows" => {
         create_strategies!(Windows, Windows);
-    },
+    }
     any(target_os = "macos", target_os = "ios") => {
         create_strategies!(Apple, Xdg);
-    },
+    }
     _ => {
         create_strategies!(Xdg, Xdg);
     }

--- a/src/base_strategy.rs
+++ b/src/base_strategy.rs
@@ -50,12 +50,14 @@ macro_rules! create_strategies {
     };
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(target_os = "windows")] {
+cfg_select! {
+    target_os = "windows" => {
         create_strategies!(Windows, Windows);
-    } else if #[cfg(any(target_os = "macos", target_os = "ios"))] {
+    },
+    any(target_os = "macos", target_os = "ios") => {
         create_strategies!(Apple, Xdg);
-    } else {
+    },
+    _ => {
         create_strategies!(Xdg, Xdg);
     }
 }

--- a/src/base_strategy.rs
+++ b/src/base_strategy.rs
@@ -53,10 +53,10 @@ macro_rules! create_strategies {
 cfg_select! {
     target_os = "windows" => {
         create_strategies!(Windows, Windows);
-    },
+    }
     any(target_os = "macos", target_os = "ios") => {
         create_strategies!(Apple, Xdg);
-    },
+    }
     _ => {
         create_strategies!(Xdg, Xdg);
     }


### PR DESCRIPTION
Hello! This PR drops the `cfg-if` dependency, favouring `cfg_select!` *(docs: [`cfg_select!`](https://doc.rust-lang.org/std/macro.cfg_select.html))*, while updating the README and **bumping version to 0.12.** *(emphasized as it seems significant and i want to make sure it's spotted)*

Passes tests, but only tested on macOS.

readme update, relating to MSRV and past version history is a little silly *(what I did to it, I mean)*, but that's okay. Will make changes if requested :)

*unnecessary rambling*:
Was looking at this crate--its name caught my eye while looking at the dependencies of `jj`--and saw that `cfg-if` recommended using a standard-library macro that recently appeared to stabilize. As doing that dropped the only dependency for non-windows platforms, I thought it would be fun and very very satisfying *(i was correct!)*.

hope you're well~